### PR TITLE
To overwrite with new records  when there updates

### DIFF
--- a/ecl/das/das_register_util.ecl
+++ b/ecl/das/das_register_util.ecl
@@ -27,11 +27,17 @@ EXPORT das_register_util := MODULE
 
     dashChartRec updateCurrentFileData(DATASET(dashChartRec) newFile) := FUNCTION
 
+    dashChartRec updateCurrentFileData(DATASET(dashChartRec) newFile) := FUNCTION
+
          return JOIN(currentFile, newFile,
                      Left.application_id = right.application_id And Left.dashboard_id = right.dashboard_id  and Left.chart_id = right.chart_id,
-                     TRANSFORM(dashChartRec, SELF := IF(Left.application_id = '' And Left.dashboard_id = '' and Left.chart_id = '', RIGHT, LEFT)),
-										 FULL OUTER
+                     TRANSFORM(dashChartRec, 
+			 self := IF(Left.application_id = RIGHT.application_id And Left.dashboard_id = RIGHT.dashboard_id and Left.chart_id = RIGHT.dashboard_id, RIGHT,
+					IF(Left.application_id = '' And Left.dashboard_id = '' and Left.chart_id = '', RIGHT, LEFT)
+				  )
+			  ), FULL OUTER
                 );
+    END;
     END;
 
     rewriteMyFile(Dataset(dashChartRec) newData, STRING chart_id) := Function


### PR DESCRIPTION
when there is a update in the registration call, this change will update the old entry with new input values, the current one was just skipping the new records